### PR TITLE
リファクタリング: Attributeデータ構造の変更

### DIFF
--- a/nodejs/src/components/Canvas.vue
+++ b/nodejs/src/components/Canvas.vue
@@ -478,7 +478,6 @@ const addNode_ = (
   axios(config)
     .then((response) => {
       // レスポンスを処理
-      // console.log(response.data);
       const node = convertToNode(response.data.node);
 
       // 表示済みならノードを追加しない
@@ -549,7 +548,6 @@ const addNode = (
   nodeId: string,
   data: { position: Position; attribute: Attribute }
 ) => {
-  // console.log(data);
   const id = data.attribute.content.value;
   const ids = Array.isArray(id) ? id : [id];
   ids.forEach((id, idx) => {
@@ -662,25 +660,21 @@ const closeSearch = () => {
 };
 
 // ドラッグオーバーイベントのハンドラ
-const handleDragEnter = (event: DragEvent) => {
+const handleDragEvent = (event: DragEvent, isOver: boolean) => {
   if (event.dataTransfer?.types?.includes("Files")) {
     event.stopPropagation();
     event.preventDefault();
-    isDraggingOver.value = true;
+    isDraggingOver.value = isOver;
   }
 };
 
-const handleDragLeave = (event: DragEvent) => {
-  if (event.dataTransfer?.types?.includes("Files")) {
-    event.stopPropagation();
-    event.preventDefault();
-    isDraggingOver.value = false;
-  }
-};
+const handleDragEnter = (event: DragEvent) => handleDragEvent(event, true);
+
+const handleDragLeave = (event: DragEvent) => handleDragEvent(event, false);
 
 const handleDragOver = (event: DragEvent) => {
+  // For dragover, browsers usually need preventDefault to allow drop
   if (event.dataTransfer?.types?.includes("Files")) {
-    event.stopPropagation();
     event.preventDefault();
     isDraggingOver.value = true;
   }

--- a/nodejs/src/components/Canvas.vue
+++ b/nodejs/src/components/Canvas.vue
@@ -173,7 +173,7 @@ function drag(event: MouseEvent) {
         const right = nodePosition.x + 200;
         const top = nodePosition.y;
         const length = node.attributes.filter((attr) =>
-          hasValue(attr.contents)
+          hasValue(attr.content)
         ).length;
         // ヘッダーの高さ44px、bodyのpadding20px、属性の高さ29px
         const bottom = nodePosition.y + 44 + 20 + 29 * length;
@@ -311,20 +311,20 @@ function convertToNode(data: any): IfcNode {
   for (const attr of data.attributes) {
     const attribute = {
       name: attr.name,
-      contents: attr.contents,
+      content: attr.content,
       edgePosition: { x: attr.inverse ? 0 : 200, y: 68 + count * 29 },
       inverse: attr.inverse,
     };
-    hasValue(attr.contents) && count++;
+    hasValue(attr.content) && count++;
     node.attributes.push(attribute);
   }
 
-  if (data.references.contents.length === 0) {
+  if (data.references.content.value.length === 0) {
     return node;
   }
   const reference = {
     name: "Reference",
-    contents: data.references.contents,
+    content: data.references.content,
     edgePosition: { x: 0, y: 25 },
     inverse: true,
   };
@@ -488,8 +488,11 @@ const addNode_ = (
 
       // nodeIdと一致するattributeのnameを取得
       const targetAttr = node.attributes.find((attr) => {
-        if (attr.contents.find((c) => c.type === "id" && c.value === srcId)) {
-          return true;
+        if (attr.content.type !== "id") return false;
+        if (Array.isArray(attr.content.value)) {
+          return attr.content.value.includes(srcId);
+        } else {
+          return attr.content.value === srcId;
         }
       });
 
@@ -547,12 +550,12 @@ const addNode = (
   data: { position: Position; attribute: Attribute }
 ) => {
   // console.log(data);
-  const id = data.attribute.contents;
+  const id = data.attribute.content.value;
   const ids = Array.isArray(id) ? id : [id];
   ids.forEach((id, idx) => {
     addNode_(
       nodeId,
-      id.value as string,
+      id as string,
       data.attribute.name,
       data.attribute.inverse,
       data.position,

--- a/nodejs/src/components/NodeComponent.vue
+++ b/nodejs/src/components/NodeComponent.vue
@@ -191,8 +191,8 @@ const onDotMouseUp = (attribute: Attribute) => {
 };
 
 // id判定
-const isId = (contents: AttrContent[]): boolean => {
-  return contents[0].type === "id";
+const isId = (content: AttrContent): boolean => {
+  return content.type === "id";
 };
 </script>
 
@@ -224,7 +224,7 @@ const isId = (contents: AttrContent[]): boolean => {
       <template v-for="(attribute, _) in node.attributes" :key="attribute.name">
         <div
           class="attribute"
-          v-if="hasValue(attribute.contents)"
+          v-if="hasValue(attribute.content)"
           :class="{ 'inverse-attribute': attribute.inverse }"
         >
           <span class="truncate-text" :title="attribute.name">{{
@@ -232,7 +232,7 @@ const isId = (contents: AttrContent[]): boolean => {
           }}</span>
           <span
             class="dot"
-            v-if="isId(attribute.contents)"
+            v-if="isId(attribute.content)"
             @mousedown.prevent="(event) => onDotMouseDown(event, attribute)"
           ></span>
         </div>

--- a/nodejs/src/components/PropertyArea.vue
+++ b/nodejs/src/components/PropertyArea.vue
@@ -6,29 +6,29 @@ const props = defineProps<{
 }>();
 props;
 
-const stringifyContents = (contents: AttrContent[]) => {
-  if (contents.length === 0) {
-    return "";
-  } else if (contents[0].type === "id") {
-    // TODO: ID表記処理がごり押しなので注意
-    return contents
-      .map((c) => (typeof c.value === "number" ? `#${c.value}` : c.value))
-      .join(", ");
-  } else {
-    return contents
-      .map((c) => {
-        if (Array.isArray(c.value)) {
-          return `(${c.value
-            .map((v) =>
-              typeof v === "object" && v !== null ? JSON.stringify(v) : v
-            )
-            .join(", ")})`;
-        } else {
-          return `${c.value}`;
-        }
-      })
-      .join(", ");
+const stringifyValue = (value: any): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map(stringifyValue).join(", ")}]`;
   }
+  if (typeof value === "object" && value !== null) {
+    return JSON.stringify(value);
+  }
+  return `${value}`;
+};
+const stringifyId = (value: any): string => {
+  // TODO: ifc, ifcx のID判定表記処理がごり押しなので注意
+  if (Array.isArray(value)) {
+    return value.map((v) => (typeof v === "number" ? `#${v}` : v)).join(", ");
+  }
+  return typeof value === "number" ? `#${value}` : `${value}`;
+};
+const stringifyContents = (content: AttrContent): string => {
+  if (!content || content.value == null) return "";
+
+  if (content.type === "id") {
+    return stringifyId(content.value);
+  }
+  return stringifyValue(content.value);
 };
 </script>
 
@@ -52,7 +52,7 @@ const stringifyContents = (contents: AttrContent[]) => {
           :key="attribute.name"
         >
           <td>{{ attribute.name }}</td>
-          <td>{{ stringifyContents(attribute.contents) }}</td>
+          <td>{{ stringifyContents(attribute.content) }}</td>
         </tr>
       </tbody>
     </table>
@@ -72,7 +72,7 @@ const stringifyContents = (contents: AttrContent[]) => {
             :key="attribute.name"
           >
             <td>{{ attribute.name }}</td>
-            <td>{{ stringifyContents(attribute.contents) }}</td>
+            <td>{{ stringifyContents(attribute.content) }}</td>
           </tr>
         </tbody>
       </table>
@@ -88,7 +88,7 @@ const stringifyContents = (contents: AttrContent[]) => {
         </thead>
         <tbody>
           <tr>
-            <td>{{ stringifyContents(node.reference.contents) }}</td>
+            <td>{{ stringifyContents(node.reference.content) }}</td>
           </tr>
         </tbody>
       </table>

--- a/nodejs/src/components/interfaces.ts
+++ b/nodejs/src/components/interfaces.ts
@@ -9,14 +9,14 @@ export interface IfcNode {
 
 export interface Attribute {
   name: string;
-  contents: AttrContent[]; // 接続先のIDまたはテキストデータ
+  content: AttrContent; // 接続先のIDまたはテキストデータ
   inverse: boolean;
   edgePosition: Position; // エッジの接続位置
 }
 
 export interface AttrContent {
   type: string;
-  value: string | number;
+  value: string | number | (string | number)[];
 }
 
 // attrName = undefined はノードの左上に接続されているとき

--- a/nodejs/src/components/utils.ts
+++ b/nodejs/src/components/utils.ts
@@ -1,6 +1,10 @@
 import { AttrContent } from "./interfaces";
 
 // attributeに値があるかどうか
-export function hasValue(contents: AttrContent[]): boolean {
-  return contents.length > 0;
+export function hasValue(content: AttrContent): boolean {
+  if (Array.isArray(content.value)) {
+    return content.value.length > 0;
+  } else {
+    return content.value != null;
+  }
 }

--- a/python/fastapi_server.py
+++ b/python/fastapi_server.py
@@ -33,7 +33,7 @@ app.mount("/dist", StaticFiles(directory="dist", html=True))
 
 # ファイルアップロードの設定
 UPLOAD_FOLDER = Path("uploads")
-ALLOWED_EXTENSIONS = {".ifc", ".ifcx"}
+ALLOWED_EXTENSIONS = {".ifc", ".ifcx"}  # NOSONAR
 UPLOAD_FOLDER.mkdir(parents=True, exist_ok=True)
 
 
@@ -67,8 +67,7 @@ async def upload_file(files: List[UploadFile] = File(...)):
 
         # ファイルを保存
         contents = await file.read()
-        with open(file_path, "wb") as f:
-            f.write(contents)
+        Path(file_path).write_bytes(contents)
 
     # IFCファイルの処理
     try:
@@ -114,7 +113,7 @@ async def get_search_data(request: SearchDataRequest):
         if request.path.endswith(".ifc"):
             search_data = ifc.get_search_data(request.path)
         elif request.path.endswith(".ifcx"):
-            search_data = ifcx.get_search_data(request.path)
+            search_data = ifcx.get_search_data()
 
         return {
             "message": "検索データ取得に成功しました。",

--- a/python/models.py
+++ b/python/models.py
@@ -10,8 +10,7 @@ class Content(BaseModel):
 
 class Attribute(BaseModel):
     name: str
-    # TODO: content: Content に変更する
-    contents: List[Content]
+    content: Content
     inverse: bool
 
 


### PR DESCRIPTION
## 変更内容

属性（Attribute）のデータ構造をリファクタリングし、`contents` フィールドを `content` に統一しました。これにより、データ構造の一貫性が向上し、コードの可読性とメンテナンス性が改善されました。

- `contents: List[Content]` から `content: Content` に変更
- フロントエンド・バックエンド両方でのデータ構造統一
- 値の有無判定ロジックの改善
- ドラッグ&ドロップイベントハンドリングの最適化

## ファイルごとの概要

| File | Description |
| ---- | ----------- |
| `nodejs/src/components/Canvas.vue` | 属性のcontents → contentに変更、ドラッグイベントハンドリングの最適化 |
| `nodejs/src/components/NodeComponent.vue` | isId関数の引数をcontentに変更、条件分岐の修正 |
| `nodejs/src/components/PropertyArea.vue` | stringifyContents関数を改善、content単体での値表示に対応 |
| `nodejs/src/components/interfaces.ts` | Attributeインターフェースのcontentsをcontentに変更、型定義の更新 |
| `nodejs/src/components/utils.ts` | hasValue関数をcontent単体で処理するよう変更 |
| `python/fastapi_server.py` | ファイル書き込み処理の最適化、NOSONARコメント追加 |
| `python/ifc_accessor.py` | attribute_info関数の改善、Contentオブジェクトでの値構築に変更 |
| `python/ifcx_alpha_accessor.py` | 同様にContentオブジェクトでの属性構築に変更 |
| `python/models.py` | Attributeモデルのcontents → contentに変更、List[Content] → Contentに型変更 |