### PR TITLE
[codex] Fix UI regressions around typography and scrollbars

### DIFF
--- a/nodejs/src/components/Canvas.vue
+++ b/nodejs/src/components/Canvas.vue
@@ -218,7 +218,11 @@ function drag(event: MouseEvent) {
           hasValue(attr.content),
         ).length;
         // ヘッダーの高さ32px、bodyのpadding16px(上下各8px)、属性の高さ24px+margin4px=28px
-        const bottom = nodePosition.y + 32 + 16 + 28 * length;
+        const bottom =
+          nodePosition.y +
+          NODE_HEADER_HEIGHT +
+          NODE_BODY_PADDING_Y * 2 +
+          ATTRIBUTE_EDGE_ROW_GAP * length;
 
         // 選択開始前に選択済みのノードは処理しない
         if (!previousSelectedNodeIds.value.includes(node.id)) {
@@ -338,6 +342,15 @@ const handleDrop = (event: DragEvent) => {
   }
 };
 
+const NODE_WIDTH = 200;
+const NODE_HEADER_HEIGHT = 32;
+const NODE_BODY_PADDING_Y = 8;
+const ATTRIBUTE_HEIGHT = 24;
+const REFERENCE_EDGE_Y = NODE_HEADER_HEIGHT / 2 + 0.5;
+const ATTRIBUTE_EDGE_START_Y =
+  NODE_HEADER_HEIGHT + NODE_BODY_PADDING_Y + ATTRIBUTE_HEIGHT / 2 + 0.5;
+const ATTRIBUTE_EDGE_ROW_GAP = 28;
+
 // レスポンスデータをNodeに変換
 function convertToNode(data: any): IfcNode {
   const node: IfcNode = {
@@ -354,7 +367,10 @@ function convertToNode(data: any): IfcNode {
     const attribute = {
       name: attr.name,
       content: attr.content,
-      edgePosition: { x: attr.inverse ? 0 : 200, y: 52 + count * 28 },
+      edgePosition: {
+        x: attr.inverse ? 0 : NODE_WIDTH,
+        y: ATTRIBUTE_EDGE_START_Y + count * ATTRIBUTE_EDGE_ROW_GAP,
+      },
       inverse: attr.inverse,
     };
     hasValue(attr.content) && count++;
@@ -367,7 +383,7 @@ function convertToNode(data: any): IfcNode {
   const reference = {
     name: "Reference",
     content: data.references.content,
-    edgePosition: { x: 0, y: 16 },
+    edgePosition: { x: 0, y: REFERENCE_EDGE_Y },
     inverse: true,
   };
   node.reference = reference;

--- a/nodejs/src/components/Canvas.vue
+++ b/nodejs/src/components/Canvas.vue
@@ -1249,7 +1249,7 @@ const handleDragOver = (event: DragEvent) => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.8rem;
+  font-size: 0.9rem;
   font-weight: 600;
   color: var(--text-secondary);
   background: var(--bg-panel);
@@ -1281,7 +1281,7 @@ const handleDragOver = (event: DragEvent) => {
   align-items: center;
   gap: 5px;
   padding: 4px 12px;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   font-weight: 500;
   color: var(--text-secondary);
   background: var(--bg-panel);
@@ -1337,7 +1337,7 @@ const handleDragOver = (event: DragEvent) => {
   border-radius: 6px;
   background: var(--bg-surface);
   color: var(--text-secondary);
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   line-height: 1;
   cursor: pointer;
   transition:
@@ -1510,7 +1510,7 @@ const handleDragOver = (event: DragEvent) => {
   height: 120px;
   padding: 24px;
   color: var(--text-muted);
-  font-size: 0.8rem;
+  font-size: 0.9rem;
   text-align: center;
 }
 

--- a/nodejs/src/components/NodeComponent.vue
+++ b/nodejs/src/components/NodeComponent.vue
@@ -264,7 +264,8 @@ const isId = (content: AttrContent): boolean => {
   background-color: var(--node-header-bg);
   border-radius: 8px 8px 0 0;
   border-bottom: 1px solid var(--border-color);
-  padding: 8px 10px;
+  height: 32px;
+  padding: 7px 10px;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/nodejs/src/components/NodeComponent.vue
+++ b/nodejs/src/components/NodeComponent.vue
@@ -273,14 +273,14 @@ const isId = (content: AttrContent): boolean => {
 
 .id {
   font-weight: 700;
-  font-size: 0.7rem;
+  font-size: 0.8rem;
   color: var(--text-muted);
   flex-shrink: 0;
 }
 
 .title {
   font-weight: 600;
-  font-size: 0.8rem;
+  font-size: 0.85rem;
   color: var(--text-primary);
   flex: 1;
   min-width: 0;
@@ -331,7 +331,7 @@ const isId = (content: AttrContent): boolean => {
   justify-content: space-between;
   height: 24px;
   line-height: 24px;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   color: var(--text-secondary);
 }
 

--- a/nodejs/src/components/PropertyArea.vue
+++ b/nodejs/src/components/PropertyArea.vue
@@ -103,7 +103,7 @@ const stringifyContents = (content: AttrContent): string => {
 
 .property-area h3 {
   margin: 0 0 12px;
-  font-size: 0.9rem;
+  font-size: 1.1rem;
   font-weight: 700;
   color: var(--text-primary);
   border-bottom: 1px solid var(--border-color);
@@ -112,7 +112,7 @@ const stringifyContents = (content: AttrContent): string => {
 
 .property-area h4 {
   margin: 14px 0 6px;
-  font-size: 0.8rem;
+  font-size: 0.95rem;
   font-weight: 600;
   color: var(--text-secondary);
   text-transform: uppercase;
@@ -121,7 +121,7 @@ const stringifyContents = (content: AttrContent): string => {
 
 .property-area p {
   margin: 4px 0;
-  font-size: 0.8rem;
+  font-size: 0.95rem;
   color: var(--text-primary);
 }
 
@@ -143,7 +143,7 @@ th,
 td {
   padding: 6px 10px;
   text-align: left;
-  font-size: 0.78rem;
+  font-size: 0.8rem;
   border-bottom: 1px solid var(--border-color);
   color: var(--text-primary);
 }
@@ -153,7 +153,7 @@ th {
   font-weight: 600;
   color: var(--text-secondary);
   text-transform: uppercase;
-  font-size: 0.7rem;
+  font-size: 0.75rem;
   letter-spacing: 0.04em;
 }
 

--- a/nodejs/src/components/SearchEntity.vue
+++ b/nodejs/src/components/SearchEntity.vue
@@ -166,7 +166,7 @@ watch(
 
 <style scoped>
 .menu-container {
-  font-size: 0.8rem;
+  font-size: 0.85rem;
   position: relative;
 }
 
@@ -187,7 +187,7 @@ watch(
   border-radius: 6px;
   background: var(--bg-panel);
   color: var(--text-primary);
-  font-size: 0.8rem;
+  font-size: 0.85rem;
   outline: none;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
@@ -264,7 +264,7 @@ watch(
 }
 
 .sub-list .sub-item {
-  font-size: 0.78rem;
+  font-size: 0.85rem;
   color: var(--text-secondary);
 }
 

--- a/nodejs/src/components/SearchEntity.vue
+++ b/nodejs/src/components/SearchEntity.vue
@@ -214,7 +214,38 @@ watch(
 .main-list {
   max-height: 500px;
   overflow: auto;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
   background-color: var(--bg-surface);
+}
+
+.main-list::-webkit-scrollbar,
+.sub-list-container::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+
+.main-list::-webkit-scrollbar-track,
+.sub-list-container::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+
+.main-list::-webkit-scrollbar-thumb,
+.sub-list-container::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb);
+  border-radius: 999px;
+  border: 3px solid var(--scrollbar-track);
+}
+
+.main-list::-webkit-scrollbar-thumb:hover,
+.sub-list-container::-webkit-scrollbar-thumb:hover {
+  background-color: var(--scrollbar-thumb-hover);
+}
+
+.main-list::-webkit-scrollbar-corner,
+.sub-list-container::-webkit-scrollbar-corner {
+  background: var(--scrollbar-track);
 }
 
 /* Sub-list panel */
@@ -231,6 +262,10 @@ watch(
   max-width: 500px;
   max-height: 500px;
   overflow: auto;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+  background-color: var(--bg-surface);
 }
 
 /* List items */

--- a/nodejs/src/components/ThemeToggle.vue
+++ b/nodejs/src/components/ThemeToggle.vue
@@ -54,7 +54,7 @@ const toggle = () => {
   border: 1px solid var(--border-color);
   border-radius: 20px;
   cursor: pointer;
-  font-size: 0.75rem;
+  font-size: 0.85rem;
   color: var(--text-secondary);
   box-shadow: var(--shadow-sm);
   transition:
@@ -108,7 +108,7 @@ const toggle = () => {
 }
 
 .toggle-label {
-  font-size: 0.85rem;
+  font-size: 0.95rem;
   line-height: 1;
 }
 </style>

--- a/nodejs/src/components/VirtualScroll.vue
+++ b/nodejs/src/components/VirtualScroll.vue
@@ -78,6 +78,32 @@ onMounted(() => {
 <style scoped>
 .scroll-container {
   overflow-y: auto;
-  border: 1px solid #ccc;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+  background-color: var(--bg-surface);
+}
+
+.scroll-container::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+
+.scroll-container::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+
+.scroll-container::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb);
+  border-radius: 999px;
+  border: 3px solid var(--scrollbar-track);
+}
+
+.scroll-container::-webkit-scrollbar-thumb:hover {
+  background-color: var(--scrollbar-thumb-hover);
+}
+
+.scroll-container::-webkit-scrollbar-corner {
+  background: var(--scrollbar-track);
 }
 </style>

--- a/nodejs/src/style.css
+++ b/nodejs/src/style.css
@@ -111,7 +111,7 @@ body {
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
     Arial, sans-serif;
-  font-size: 14px;
+  font-size: 16px;
   color: var(--text-primary);
   background-color: var(--bg-canvas);
   transition:


### PR DESCRIPTION
## What changed
- restored UI sizing closer to the previous viewer across the canvas, node cards, property area, search panel, and theme toggle
- aligned node edge anchor positions with the updated header/body measurements so connections stay visually centered
- added themed scrollbar styling to the entity search lists and virtual scroll container, including dark mode support

## Why
Recent UI tweaks introduced a few regressions: typography became smaller than intended, node connection anchors drifted from the visual center after spacing changes, and scrollbars in list-heavy panels looked inconsistent in dark mode.

## Impact
- improves readability across the main viewer UI
- keeps graph edge attachment points aligned with node content
- makes search and virtualized lists feel more consistent with the app theme

## Root cause
A set of hard-coded sizing values in the canvas node geometry and component styles fell out of sync after earlier UI adjustments, and list containers were still relying on default browser scrollbar rendering.

## Validation
- `npm run build` (in `nodejs/`)
