### PR TITLE
[codex] Fix inline IFC attribute serialization

### DIFF
--- a/python/ifc_accessor.py
+++ b/python/ifc_accessor.py
@@ -108,7 +108,7 @@ def attribute_info(key: str, val, inverse: bool) -> Attribute:
     def _instance2content(val):
         if val.id() == 0:
             # IFCXX($,$,IFCINTEGER(2),$) みたく直接IFCの場合
-            return Content(type="value", value=val.wrappedValue)
+            return Content(type="value", value=str(val))
         else:
             return Content(type="id", value=val.id())
 
@@ -116,8 +116,9 @@ def attribute_info(key: str, val, inverse: bool) -> Attribute:
         return Attribute(name=key, content=_instance2content(val), inverse=inverse)
     elif isinstance(val, tuple):
         if all(isinstance(v, ifcopenshell.entity_instance) for v in val):
+            content_type = "value" if len(val) > 0 and val[0].id() == 0 else "id"
             values = [_instance2content(v).value for v in val]
-            content = Content(type="id", value=values)
+            content = Content(type=content_type, value=values)
             return Attribute(name=key, content=content, inverse=inverse)
         else:
             # (0, 0, 0) みたいな座標の場合


### PR DESCRIPTION
## What changed
Inline IFC values are now displayed with their wrapper type information preserved.

Examples of the affected data:

```text
[IfcLineIndex((1,2)), IfcArcIndex((2,3,4)), IfcLineIndex((4,5)), IfcArcIndex((5,6,1))]
IfcLabel('2008')
```

Previously these were displayed as:

```text
(1,2), (2,3,4), (4,5), (5,6,1)
2008
```

That meant type information such as `IfcLineIndex`, `IfcArcIndex`, and `IfcLabel` was lost.

## Why
The viewer should preserve the original IFC wrapper types when showing inline values so the displayed data matches the source structure more faithfully.

## Root cause
Direct IFC wrapper instances were serialized using `wrappedValue`, and tuples of wrapper instances were treated as plain values or IDs instead of keeping their IFC type representation.

## Impact
This makes inline IFC values easier to inspect correctly because the displayed output retains the original IFC type names.

## Validation
- `PYTHONPYCACHEPREFIX=/tmp python3 -m py_compile python/ifc_accessor.py`
