### PR TITLE
Reduce Windows false positives for Nuitka build

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ run `ifc-graph-viewer.exe`.
 After setting up the environment as described in [Method 2: Build](#method-2-build), run the following command:
 
 ```sh
-uv run nuitka --standalone --follow-imports app.py --output-dir=../dist --include-data-dir=dist=dist --output-filename=ifc-graph-viewer
+uv run nuitka --standalone --follow-imports --windows-console-mode=disable --company-name="Your Name or Org" --product-name="IFC Graph Viewer" --file-version=0.1.0.0 --product-version=0.1.0 --file-description="IFC Graph Viewer" app.py --output-dir=../dist --include-data-dir=dist=dist --output-filename=ifc-graph-viewer
 ```
 
 ## Basic Usage Guide

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ run `ifc-graph-viewer.exe`.
 After setting up the environment as described in [Method 2: Build](#method-2-build), run the following command:
 
 ```sh
-uv run nuitka --standalone --follow-imports --windows-console-mode=disable --company-name="Your Name or Org" --product-name="IFC Graph Viewer" --file-version=0.1.0.0 --product-version=0.1.0 --file-description="IFC Graph Viewer" app.py --output-dir=../dist --include-data-dir=dist=dist --output-filename=ifc-graph-viewer
+uv run nuitka app.py --standalone --follow-imports --windows-console-mode=disable --output-dir=../dist --include-data-dir=dist=dist --output-filename=ifc-graph-viewer
 ```
 
 ## Basic Usage Guide

--- a/README_ja.md
+++ b/README_ja.md
@@ -66,7 +66,7 @@ Python を動かした状態で「localhost:8000」にブラウザでアクセ�
 [方法 2：ビルド](#方法-2ビルド) で実行できる状態にしてから、以下のコマンドを実行。
 
 ```sh
-uv run nuitka --standalone --follow-imports app.py --output-dir=../dist --include-data-dir=dist=dist --output-filename=ifc-graph-viewer
+uv run nuitka --standalone --follow-imports --windows-console-mode=disable --company-name="Your Name or Org" --product-name="IFC Graph Viewer" --file-version=0.1.0.0 --product-version=0.1.0 --file-description="IFC Graph Viewer" app.py --output-dir=../dist --include-data-dir=dist=dist --output-filename=ifc-graph-viewer
 ```
 
 ## 使い方簡易説明

--- a/README_ja.md
+++ b/README_ja.md
@@ -66,7 +66,7 @@ Python を動かした状態で「localhost:8000」にブラウザでアクセ�
 [方法 2：ビルド](#方法-2ビルド) で実行できる状態にしてから、以下のコマンドを実行。
 
 ```sh
-uv run nuitka --standalone --follow-imports --windows-console-mode=disable --company-name="Your Name or Org" --product-name="IFC Graph Viewer" --file-version=0.1.0.0 --product-version=0.1.0 --file-description="IFC Graph Viewer" app.py --output-dir=../dist --include-data-dir=dist=dist --output-filename=ifc-graph-viewer
+uv run nuitka app.py --standalone --follow-imports --windows-console-mode=disable --output-dir=../dist --include-data-dir=dist=dist --output-filename=ifc-graph-viewer
 ```
 
 ## 使い方簡易説明

--- a/python/app.py
+++ b/python/app.py
@@ -6,9 +6,9 @@ import webview
 from fastapi_server import app as server
 
 
-def find_free_port():
+def find_free_port(host="127.0.0.1"):
     s = socket.socket()
-    s.bind(("", 0))  # OSに空いてるポートを選ばせる
+    s.bind((host, 0))  # ローカルループバックだけで空きポートを確保する
     port = s.getsockname()[1]
     s.close()
     return port

--- a/python/fastapi_server.py
+++ b/python/fastapi_server.py
@@ -1,3 +1,8 @@
+import atexit
+import os
+import shutil
+import sys
+import tempfile
 import traceback
 from pathlib import Path
 from typing import List, Union
@@ -11,7 +16,6 @@ from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
-# アプリケーションの初期化
 app = FastAPI()
 
 origins = [
@@ -29,18 +33,27 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-Path("dist").mkdir(parents=True, exist_ok=True)
-app.mount("/dist", StaticFiles(directory="dist", html=True))
+def get_app_root() -> Path:
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).resolve().parent
+    return Path(__file__).resolve().parent
+
+
+APP_ROOT = get_app_root()
+DIST_DIR = APP_ROOT / "dist"
+app.mount("/dist", StaticFiles(directory=str(DIST_DIR), html=True, check_dir=False))
 
 # ファイルアップロードの設定
-UPLOAD_FOLDER = Path("uploads")
+UPLOAD_ROOT = Path(tempfile.mkdtemp(prefix="ifc-graph-viewer-"))
+UPLOAD_FOLDER = UPLOAD_ROOT / "uploads"
 ALLOWED_EXTENSIONS = {".ifc", ".ifcx"}  # NOSONAR
 UPLOAD_FOLDER.mkdir(parents=True, exist_ok=True)
+atexit.register(lambda: shutil.rmtree(UPLOAD_ROOT, ignore_errors=True))
 
 
 @app.get("/", response_class=HTMLResponse)
 async def read_root():
-    return FileResponse("dist/index.html")
+    return FileResponse(DIST_DIR / "index.html")
 
 
 def allowed_file(filename: str) -> bool:


### PR DESCRIPTION
## Summary
- bind the desktop app's ephemeral port to `127.0.0.1` instead of all interfaces
- resolve the packaged app root from `sys.executable` so bundled `dist` assets are served correctly when frozen
- write uploaded IFC files to a temporary runtime directory and clean it up on exit
- update the English and Japanese build commands to include `--windows-console-mode=disable`

## Why
The Windows Nuitka build could trigger avoidable false positives because the app reserved a free port on every interface and still assumed source-layout paths at runtime. Tightening the port binding to loopback and resolving packaged asset paths from the frozen executable reduces that exposure while keeping the packaged app functional.

## Validation
- `npm run build`
- `uv run python -m compileall python`
