### PR TITLE
[codex] Improve component typography readability

### DIFF
--- a/nodejs/src/components/Canvas.vue
+++ b/nodejs/src/components/Canvas.vue
@@ -1265,7 +1265,7 @@ const handleDragOver = (event: DragEvent) => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   font-weight: 600;
   color: var(--text-secondary);
   background: var(--bg-panel);
@@ -1297,7 +1297,7 @@ const handleDragOver = (event: DragEvent) => {
   align-items: center;
   gap: 5px;
   padding: 4px 12px;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
   font-weight: 500;
   color: var(--text-secondary);
   background: var(--bg-panel);
@@ -1353,7 +1353,7 @@ const handleDragOver = (event: DragEvent) => {
   border-radius: 6px;
   background: var(--bg-surface);
   color: var(--text-secondary);
-  font-size: 0.875rem;
+  font-size: 0.9rem;
   line-height: 1;
   cursor: pointer;
   transition:
@@ -1526,7 +1526,7 @@ const handleDragOver = (event: DragEvent) => {
   height: 120px;
   padding: 24px;
   color: var(--text-muted);
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   text-align: center;
 }
 

--- a/nodejs/src/components/HeaderInfoArea.vue
+++ b/nodejs/src/components/HeaderInfoArea.vue
@@ -177,7 +177,7 @@ const getIfcHeader = (header: IfcHeader): IfcStructuredHeader => header as IfcSt
 
 .header-info-area h3 {
   margin: 0 0 4px;
-  font-size: 0.9rem;
+  font-size: 1.15rem;
   font-weight: 700;
   color: var(--text-primary);
   border-bottom: 1px solid var(--border-color);
@@ -190,7 +190,7 @@ const getIfcHeader = (header: IfcHeader): IfcStructuredHeader => header as IfcSt
 
 .filename-label {
   margin: 12px 0 8px;
-  font-size: 0.78rem;
+  font-size: 0.9rem;
   font-weight: 600;
   color: var(--text-muted);
   word-break: break-all;
@@ -198,7 +198,7 @@ const getIfcHeader = (header: IfcHeader): IfcStructuredHeader => header as IfcSt
 
 .header-info-area h4 {
   margin: 14px 0 6px;
-  font-size: 0.8rem;
+  font-size: 1rem;
   font-weight: 600;
   color: var(--text-secondary);
   text-transform: uppercase;
@@ -216,7 +216,7 @@ table {
 td {
   padding: 6px 10px;
   text-align: left;
-  font-size: 0.78rem;
+  font-size: 0.85rem;
   border-bottom: 1px solid var(--border-color);
   color: var(--text-primary);
   word-break: break-all;

--- a/nodejs/src/components/NodeComponent.vue
+++ b/nodejs/src/components/NodeComponent.vue
@@ -332,7 +332,7 @@ const isId = (content: AttrContent): boolean => {
   justify-content: space-between;
   height: 24px;
   line-height: 24px;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
   color: var(--text-secondary);
 }
 

--- a/nodejs/src/components/PropertyArea.vue
+++ b/nodejs/src/components/PropertyArea.vue
@@ -143,7 +143,7 @@ th,
 td {
   padding: 6px 10px;
   text-align: left;
-  font-size: 0.8rem;
+  font-size: 0.875rem;
   border-bottom: 1px solid var(--border-color);
   color: var(--text-primary);
 }
@@ -153,7 +153,7 @@ th {
   font-weight: 600;
   color: var(--text-secondary);
   text-transform: uppercase;
-  font-size: 0.75rem;
+  font-size: 0.8rem;
   letter-spacing: 0.04em;
 }
 

--- a/nodejs/src/components/SearchEntity.vue
+++ b/nodejs/src/components/SearchEntity.vue
@@ -166,7 +166,7 @@ watch(
 
 <style scoped>
 .menu-container {
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   position: relative;
 }
 
@@ -187,7 +187,7 @@ watch(
   border-radius: 6px;
   background: var(--bg-panel);
   color: var(--text-primary);
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   outline: none;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
@@ -299,7 +299,7 @@ watch(
 }
 
 .sub-list .sub-item {
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   color: var(--text-secondary);
 }
 

--- a/nodejs/src/components/ThemeToggle.vue
+++ b/nodejs/src/components/ThemeToggle.vue
@@ -54,7 +54,7 @@ const toggle = () => {
   border: 1px solid var(--border-color);
   border-radius: 20px;
   cursor: pointer;
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   color: var(--text-secondary);
   box-shadow: var(--shadow-sm);
   transition:
@@ -108,7 +108,7 @@ const toggle = () => {
 }
 
 .toggle-label {
-  font-size: 0.95rem;
+  font-size: 1rem;
   line-height: 1;
 }
 </style>


### PR DESCRIPTION
## Summary
Improve typography sizing across several Vue UI components to make labels, headings, and table content easier to read.

## What Changed
- increased font sizes in `Canvas.vue`, `NodeComponent.vue`, `SearchEntity.vue`, and `ThemeToggle.vue`
- enlarged headings and table text in `HeaderInfoArea.vue`
- adjusted property table typography in `PropertyArea.vue`

## Why
Several interface areas were using slightly undersized text, which made metadata and controls harder to scan.

## Impact
This is a visual-only UI polish change intended to improve readability without changing behavior.

## Validation
- `npm run build` in `nodejs/`